### PR TITLE
Support indexer V2

### DIFF
--- a/MachineMotion.py
+++ b/MachineMotion.py
@@ -85,7 +85,7 @@ class MECH_GAIN:
     ballscrew_10mm_turn             = 10
     legacy_ballscrew_5_mm_turn      = 5
     indexer_deg_turn                = 85
-    #indexer_deg_turn                = 36
+    indexer_v2_deg_turn             = 36
     roller_conveyor_mm_turn         = 157
     belt_conveyor_mm_turn           = 69.12
     rack_pinion_mm_turn             = 157.08


### PR DESCRIPTION
For the ticket https://github.com/VentionCo/mm-vention-control/issues/807

I added the Indexer V2 gain to the class `MECH_GAIN`.

The indexer v2 has a gain of 36 deg/turn.