### PR TITLE
Release/v3.2

### DIFF
--- a/examples/configAxis.py
+++ b/examples/configAxis.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 mm = MachineMotion(DEFAULT_IP_ADDRESS.usb_windows)

--- a/examples/configAxisDirection.py
+++ b/examples/configAxisDirection.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 mm = MachineMotion(DEFAULT_IP_ADDRESS.usb_windows)

--- a/examples/configHomingSpeed.py
+++ b/examples/configHomingSpeed.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 mm = MachineMotion(DEFAULT_IP_ADDRESS.usb_windows)

--- a/examples/configMachineMotionIp.py
+++ b/examples/configMachineMotionIp.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 #Initialize MachineMotion with default IP address

--- a/examples/configMinMaxHomingSpeed.py
+++ b/examples/configMinMaxHomingSpeed.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 mm = MachineMotion(DEFAULT_IP_ADDRESS.usb_windows)

--- a/examples/controlBrakes.py
+++ b/examples/controlBrakes.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 # Define a callback to process controller gCode responses (if desired)

--- a/examples/emitAbsoluteMove.py
+++ b/examples/emitAbsoluteMove.py
@@ -1,5 +1,5 @@
 import sys
-sys.path.append("..")
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 # Define a callback to process controller gCode responses (if desired)

--- a/examples/emitAbsoluteMove.py
+++ b/examples/emitAbsoluteMove.py
@@ -1,4 +1,4 @@
-import sys
+import sys, os
 sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 

--- a/examples/emitAcceleration.py
+++ b/examples/emitAcceleration.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 # Define a callback to process controller gCode responses (if desired)

--- a/examples/emitCombinedAxesAbsoluteMove.py
+++ b/examples/emitCombinedAxesAbsoluteMove.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 

--- a/examples/emitCombinedAxesRelativeMove.py
+++ b/examples/emitCombinedAxesRelativeMove.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 #declare parameters for combine move

--- a/examples/emitDwell.py
+++ b/examples/emitDwell.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 #Declare parameters for g-Code command

--- a/examples/emitHome.py
+++ b/examples/emitHome.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 # Define a callback to process controller gCode responses (if desired)

--- a/examples/emitHomeAll.py
+++ b/examples/emitHomeAll.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 # Define a callback to process controller gCode responses (if desired)

--- a/examples/emitRelativeMove.py
+++ b/examples/emitRelativeMove.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 # Define a callback to process controller gCode responses (if desired)

--- a/examples/emitSpeed.py
+++ b/examples/emitSpeed.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 # Define a callback to process controller gCode responses (if desired)

--- a/examples/emitStop.py
+++ b/examples/emitStop.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 import time

--- a/examples/emitgCode.py
+++ b/examples/emitgCode.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 #Declare parameters for g-Code command

--- a/examples/getCurrentPositions.py
+++ b/examples/getCurrentPositions.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 # Define a callback to process controller gCode responses (if desired)

--- a/examples/getData_saveData.py
+++ b/examples/getData_saveData.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 # Initialize the key-value pair to save on the controller

--- a/examples/getEndStopState.py
+++ b/examples/getEndStopState.py
@@ -1,14 +1,8 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
-# Define a callback to process controller gCode responses (if desired)
-def templateCallback(data):
-   print ( "Controller gCode responses " + data )
-
-mm = MachineMotion(DEFAULT_IP_ADDRESS.usb_windows, gCodeCallback = templateCallback)
-
-
+mm = MachineMotion(DEFAULT_IP_ADDRESS.usb_windows)
 
 #When starting a program, one must remove the software stop before moving
 print("--> Removing software stop")
@@ -16,39 +10,11 @@ mm.releaseEstop()
 print("--> Resetting system")
 mm.resetSystem()
 
-#Define Move Parameters
-axes = [1, 2, 3]
-speed = 400
-acceleration = 500
-direction = ["positive", "positive", "positive"]
-Position500mm = [150, 150, 150]
-mechGain = MECH_GAIN.timing_belt_150mm_turn
 
-#Load Relative Move Parameters
-mm.emitSpeed(speed)
-mm.emitAcceleration(acceleration)
-
-for i in axes:
-    mm.configAxis(i, MICRO_STEPS.ustep_8, mechGain)
-
-# Home Axis Before Move
-print("Axis " + str(axes) + " moving home.")
-mm.emitHomeAll()
-mm.waitForMotionCompletion()
-print("Axis " + str(axes) + " homed")
-
-# Get End Stop State (Homed)
-mm.getEndStopState()
-time.sleep(5.0)
-
-# Move 150mm
-mm.emitCombinedAxisRelativeMove(axes, direction, Position500mm)
-mm.waitForMotionCompletion()
-
-# Get End Stop State (not Home)
-mm.getEndStopState()
-time.sleep(5.0)
-
-mm.emitHomeAll()
-mm.waitForMotionCompletion()
-print("End of example")
+states = mm.getEndStopState()
+axis = 1
+mm.configAxisDirection(axis, "positive")
+homeSensor = states[axis]["home"]
+endSensor = states[axis]["end"]
+print("Axis " + str(axis) + " home sensor is " + homeSensor)
+print("Axis " + str(axis) + " end sensor is " + endSensor)

--- a/examples/initMachineMotion.py
+++ b/examples/initMachineMotion.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 print('Initialize MachineMotion object...')

--- a/examples/readEncoder.py
+++ b/examples/readEncoder.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 mm = MachineMotion(DEFAULT_IP_ADDRESS.usb_windows)

--- a/examples/setPosition.py
+++ b/examples/setPosition.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 mm = MachineMotion(DEFAULT_IP_ADDRESS.usb_windows)

--- a/examples/waitForMotionCompletion.py
+++ b/examples/waitForMotionCompletion.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append("..")
+import os, sys
+sys.path.append(os.path.abspath(__file__ + "/../../"))
 from MachineMotion import *
 
 # Define a callback to process controller gCode responses (if desired)


### PR DESCRIPTION
Reason for change:

Any python API script must configAxis before we configAxisDirection. 

If you try to configAxisDirection without calling configAxis, then configAxisDirection sets gain to 0 without any error message. 
If you call configAxisDrection first, and then call configAxis, then your axis will always be in a positive direction. 

Why this matters:
1) The order which I call configAxis and configAxisDirection should not matter
2) Clients will configure axis in MachineBuilder and expect that this configures axis in python as well

To resolve this:
instead of creating empty objects in mm.__init__, we read direction and steps_mm values from marlin (M503). This resolves the above issues. 

Additionally:
The sys.path.append("..") only worked if you launched the example from within the examples folder. 
for ex -` python emitAbsoluteMove.py` works, but` python examples/emitAbsoluteMove.py `returns a module import error. This change is more robust. 